### PR TITLE
rename App.Run .RunArgs to App.Parse ParseArgs

### DIFF
--- a/app.go
+++ b/app.go
@@ -84,14 +84,14 @@ func NewApp(name, brief string) *App {
 	return &app
 }
 
-// Run runs the parser, collecting the values from the command-line
+// Parse runs the parser, collecting the values from the command-line
 // and running any needed subcommands.
-func (app *App) Run() error {
-	return app.RunArgs(os.Args[1:])
+func (app *App) Parse() error {
+	return app.ParseArgs(os.Args[1:])
 }
 
-// RunArgs behave like run, but instead of looking to the command-line
+// ParseArgs behave like Parse, but instead of looking to the command-line
 // arguments, it takes an array of arguments as parameters.
-func (app *App) RunArgs(args []string) error {
+func (app *App) ParseArgs(args []string) error {
 	return app.doRun(args)
 }

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -59,7 +59,7 @@ func TestSubCommand(t *testing.T) {
 			c2 = true
 		})
 
-		if err := app.RunArgs(test.cmd); err != nil {
+		if err := app.ParseArgs(test.cmd); err != nil {
 			t.Errorf("Case %d, error running parser: %v", i, err)
 			continue
 		}
@@ -129,7 +129,7 @@ func TestCommandArgReuse(t *testing.T) {
 			})
 		})
 
-		err := app.RunArgs(test.cmd)
+		err := app.ParseArgs(test.cmd)
 		if test.expectError && !libcmd.IsParserErr(err) {
 			t.Errorf("Case %d, should have returned error", i)
 			continue
@@ -201,7 +201,7 @@ func TestCommandArgSameName(t *testing.T) {
 			})
 		})
 
-		if err := app.RunArgs(test.cmd); err != nil {
+		if err := app.ParseArgs(test.cmd); err != nil {
 			t.Errorf("Case %d, error running parser: %v", i, err)
 			continue
 		}
@@ -262,7 +262,7 @@ func TestRun(t *testing.T) {
 			})
 		})
 
-		if err := app.RunArgs(test.cmd); err != nil {
+		if err := app.ParseArgs(test.cmd); err != nil {
 			t.Errorf("Case %d, error running parser: %v", i, err)
 			continue
 		}
@@ -285,7 +285,7 @@ func TestNoMatch(t *testing.T) {
 		c1 = true
 	})
 
-	if err := app.RunArgs([]string{"", ""}); err != nil {
+	if err := app.ParseArgs([]string{"", ""}); err != nil {
 		t.Errorf("Error running parser: %v", err)
 		return
 	}

--- a/get_test.go
+++ b/get_test.go
@@ -49,7 +49,7 @@ func TestGet(t *testing.T) {
 		app.Float32("afloat32", "f32", 0, "specifies a float32 value")
 		app.Float64("afloat64", "f64", 0, "specifies a float64 value")
 
-		if err := app.RunArgs(test.cmd); err != nil {
+		if err := app.ParseArgs(test.cmd); err != nil {
 			t.Errorf("Case %d, error parsing args: %v", i, err)
 			continue
 		}
@@ -106,7 +106,7 @@ func TestGetIntLimit(t *testing.T) {
 		app.Uint32("", "g", 0, "specifies a uint32 value")
 		app.Uint64("", "h", 0, "specifies a uint64 value")
 
-		if err := app.RunArgs(test.cmd); err != nil {
+		if err := app.ParseArgs(test.cmd); err != nil {
 			t.Errorf("Case %d, error parsing args: %v", i, err)
 			continue
 		}
@@ -148,7 +148,7 @@ func TestGetChoice(t *testing.T) {
 		app := libcmd.NewApp("", "")
 		app.Choice([]string{"foo", "bar", "baz"}, "", "c", "", "")
 
-		err := app.RunArgs(test.cmd)
+		err := app.ParseArgs(test.cmd)
 		if !test.expectErr && err != nil {
 			t.Errorf("Case %d, error parsing args: %v", i, err)
 			continue

--- a/help_test.go
+++ b/help_test.go
@@ -21,7 +21,7 @@ func compareHelpOutput(app *libcmd.App, args []string, goldenfile string) error 
 
 	if len(args) == 0 {
 		app.Help()
-	} else if err := app.RunArgs(args); err != nil {
+	} else if err := app.ParseArgs(args); err != nil {
 		return err
 	}
 

--- a/opt_test.go
+++ b/opt_test.go
@@ -72,7 +72,7 @@ func TestOpt(t *testing.T) {
 		afloat32 := app.Float32("afloat32", "f32", 0, "specifies a float32 value")
 		afloat64 := app.Float64("afloat64", "f64", 0, "specifies a float64 value")
 
-		if err := app.RunArgs(test.cmd); err != nil {
+		if err := app.ParseArgs(test.cmd); err != nil {
 			t.Errorf("Case %d, error parsing args: %v", i, err)
 			continue
 		}
@@ -125,7 +125,7 @@ func TestOptDefault(t *testing.T) {
 		afloat32 := app.Float32("afloat32", "f32", float32(3.14), "specifies a float32 value")
 		afloat64 := app.Float64("afloat64", "f64", float64(3.1415), "specifies a float64 value")
 
-		if err := app.RunArgs(test.cmd); err != nil {
+		if err := app.ParseArgs(test.cmd); err != nil {
 			t.Errorf("Case %d, error parsing args: %v", i, err)
 			continue
 		}
@@ -170,7 +170,7 @@ func TestOptError(t *testing.T) {
 		app.Uint("auint", "u", 0, "specifies an uint value")
 		app.String("astring", "s", "", "specifies a string value")
 
-		err := app.RunArgs(test.cmd)
+		err := app.ParseArgs(test.cmd)
 
 		if err == nil {
 			t.Errorf("Case %d, argument parsing should return error", i)
@@ -209,7 +209,7 @@ func TestOptIntLimit(t *testing.T) {
 		c := app.Int32("", "c", 0, "specifies a int32 value")
 		d := app.Int64("", "d", 0, "specifies a int64 value")
 
-		if err := app.RunArgs(test.cmd); err != nil {
+		if err := app.ParseArgs(test.cmd); err != nil {
 			t.Errorf("Case %d, error parsing args: %v", i, err)
 			continue
 		}
@@ -243,7 +243,7 @@ func TestOptUintLimit(t *testing.T) {
 		c := app.Uint32("", "c", 0, "specifies a uint32 value")
 		d := app.Uint64("", "d", 0, "specifies a uint64 value")
 
-		if err := app.RunArgs(test.cmd); err != nil {
+		if err := app.ParseArgs(test.cmd); err != nil {
 			t.Errorf("Case %d, error parsing args: %v", i, err)
 			continue
 		}
@@ -286,7 +286,7 @@ func TestOptIntegerLimits(t *testing.T) {
 		app.Uint32("auint32", "", 0, "specifies a uint32 value")
 		app.Uint64("auint64", "", 0, "specifies a uint64 value")
 
-		err := app.RunArgs(test.cmd)
+		err := app.ParseArgs(test.cmd)
 
 		if err == nil {
 			t.Errorf("Case %d, argument parsing should return error", i)
@@ -334,7 +334,7 @@ func TestOptKeepValue(t *testing.T) {
 		*s1 = keep
 		*s2 = ""
 
-		if err := app.RunArgs(test.cmd); err != nil {
+		if err := app.ParseArgs(test.cmd); err != nil {
 			t.Errorf("Case %d, error parsing args: %v", i, err)
 			continue
 		}
@@ -361,7 +361,7 @@ func TestChoice(t *testing.T) {
 		app := libcmd.NewApp("", "")
 		s := app.Choice([]string{"foo", "bar", "baz"}, "", "c", "", "")
 
-		err := app.RunArgs(test.cmd)
+		err := app.ParseArgs(test.cmd)
 		if !test.expectErr && err != nil {
 			t.Errorf("Case %d, error parsing args: %v", i, err)
 			continue
@@ -411,7 +411,7 @@ func TestOperand(t *testing.T) {
 		s := app.String("", "s", "", "")
 		app.AddOperand("name", "")
 
-		err := app.RunArgs(test.cmd)
+		err := app.ParseArgs(test.cmd)
 		if !test.expectErr && err != nil {
 			t.Errorf("Case %d, error parsing args: %v", i, err)
 			continue
@@ -467,7 +467,7 @@ func TestOperandOptional(t *testing.T) {
 		app.AddOperand("name", "")
 		app.AddOperand("value", "?")
 
-		err := app.RunArgs(test.cmd)
+		err := app.ParseArgs(test.cmd)
 		if !test.expectErr && err != nil {
 			t.Errorf("Case %d, error parsing args: %v", i, err)
 			continue


### PR DESCRIPTION
Ref: #2 

Renamed the functions and instances in all the tests. Ran tests to ensure they are all passing.